### PR TITLE
Simplify equation for finding `R_all` in case prime == 2.

### DIFF
--- a/quadratic_sieve.py
+++ b/quadratic_sieve.py
@@ -284,9 +284,8 @@ def gen_smooth(factor_base):
         # tonelli shanks algo doesn't work with factor 2
         if factor == 2:
             # solving x*x=N % 2
-            if (sieve[0] % 2 == 0 and startpoint % 2 == 0 or
-               sieve[0] % 2 == 1 and startpoint % 2 == 1):
-                    R_all = [0]
+            if (sqrt_N ** 2 - N) % 2 == 0:
+                R_all = [0]
             else:
                 R_all = [1]
         else:


### PR DESCRIPTION
This part is a bit overkill:

``` python
if ( sieve[0] % 2 == 0 and startpoint % 2 == 0 or
     sieve[0] % 2 == 1 and startpoint % 2 == 1 ):
    ...
```

Python does provide shorthand for checking multiple value at the same time, like:

``` python
if ( sieve[0] % 2 == startpoint % 2 == 0 or
     sieve[0] % 2 == startpoint % 2 == 1 ):
    ...
```

This equation does not yet satisfy me, however. Equality check could be collapse more:

``` python
if ( (sieve[0] - startpoint) % 2 == 0 or  # case both equal to 0.
     (sieve[0] - startpoint) % 2 == 0 ):  # case both equal to 1, oops...
    ...
```

So we now have:

``` python
if (sieve[0] - startpoint) % 2 == 0:
    ...
```

But from very first, we have:

``` python
startpoint = int(math.sqrt(N)) - sieving_array_size // 2
sieve[0] = (startpoint + sqrt_N) * (startpoint + sqrt_N) - N
```

After replace this variable into if-checking make it looks like:

``` python
if (startpoint + sqrt_N) ** 2 - N - startpoint) % 2 == 0:
    ...
```

Expand power-2 and canceling even term:

``` python
if (startpoint ** 2 + sqrt_N ** 2 - N - startpoint) % 2 == 0:
    ...
```

Since we knew that `a ** 2 - a == (a - 1) * a` and makes this result even, we may cancel `startpoint ** 2 - startpoint` now:

``` python
if (sqrt_N ** 2 - N) % 2 == 0:
    ...
```

Q.E.D.
